### PR TITLE
RectOverlay class

### DIFF
--- a/examples/debug_example.py
+++ b/examples/debug_example.py
@@ -1,6 +1,6 @@
 import pygame
 import sys
-from pygkit.debug import DebugOverlay, InputOverlay
+from pygkit.debug import DebugOverlay, InputOverlay, RectOverlay
 
 # Constants
 SCREEN_WIDTH = 800
@@ -28,6 +28,14 @@ class Game:
         # Clock for controlling framerate
         self.clock = pygame.time.Clock()
 
+        # Create 3 Circle instances of different sizes and colors
+        self.circle1 = Circle(100, 100, 5, 5, 50, 50, "mediumpurple4")
+        self.circle2 = Circle(200, 200, -4, -4, 100, 100, "darkorange")
+        self.circle3 = Circle(300, 300, 3, -3, 150, 150, "darkgreen")
+
+        # Create a sprite group and add the circles to it
+        self.boxes = pygame.sprite.Group([self.circle1, self.circle2, self.circle3])
+
         # Initialize overlays
         self.debug_overlay = DebugOverlay()
         self.input_overlay = InputOverlay(
@@ -47,6 +55,7 @@ class Game:
                 [0, 0]
             ]
         )
+        self.rect_overlay = RectOverlay([self.boxes])
 
         # Set overlay fonts (debug_overlay uses default font)
         self.input_overlay.set_font(
@@ -57,12 +66,9 @@ class Game:
                 color="navy"
             )
 
-        # Create a Box instance
-        self.sprite = Box(100, 100, 5, 5, 50, 50, "mediumpurple4")
-
     def run(self):
         """Runs the game. The 1 key toggles the debug overlay, the 2 key toggles
-        the input overlay.
+        the input overlay, the 3 key toggles the rect overlay
         
         Returns:
             None
@@ -88,9 +94,9 @@ class Game:
             # Draw background
             self.screen.fill("papayawhip")
 
-            # Update and draw sprite
-            self.sprite.update()
-            self.screen.blit(self.sprite.image, self.sprite.rect)
+            # Update and draw sprites
+            self.boxes.update()
+            self.boxes.draw(self.screen)
 
             # Draw the debug overlay in the top-left corner
             self.debug_overlay.draw(
@@ -98,9 +104,9 @@ class Game:
                 background_enabled=True,
                 test_message="This is a test message.",
                 fps=round(self.clock.get_fps(), 2),
-                box_x=self.sprite.rect.x,
-                box_y=self.sprite.rect.y,
-                box_vel=self.sprite.velocity
+                small_circle_x=self.circle1.rect.x,
+                small_circle_y=self.circle1.rect.y,
+                small_circle_vel=self.circle1.velocity
             )
 
             # Draw the input overlay in the bottom-left corner
@@ -108,13 +114,16 @@ class Game:
                 position="bottomleft",
                 background_enabled=False
                 )
+            
+            # Draw the rect overlay
+            self.rect_overlay.draw()
 
             # Update the display and limit the framerate
             pygame.display.flip()
             self.clock.tick(FPS)
 
 
-class Box(pygame.sprite.Sprite):
+class Circle(pygame.sprite.Sprite):
     """
     A simple sprite that moves around the screen.
 
@@ -141,8 +150,8 @@ class Box(pygame.sprite.Sprite):
         super().__init__()
 
         # Create the sprite's image and rect
-        self.image = pygame.Surface((width, height))
-        self.image.fill(color)
+        self.image = pygame.Surface((width, height), pygame.SRCALPHA)
+        pygame.draw.circle(self.image, color, (width // 2, height // 2), width // 2)
         self.rect = self.image.get_rect(center=(x, y))
 
         # Set the sprite's velocity using a Vector2

--- a/examples/debug_example.py
+++ b/examples/debug_example.py
@@ -34,7 +34,9 @@ class Game:
         self.circle3 = Circle(300, 300, 3, -3, 150, 150, "darkgreen")
 
         # Create a sprite group and add the circles to it
-        self.boxes = pygame.sprite.Group([self.circle1, self.circle2, self.circle3])
+        self.boxes = pygame.sprite.Group(
+            [self.circle1, self.circle2, self.circle3]
+        )
 
         # Initialize overlays
         self.debug_overlay = DebugOverlay()
@@ -161,8 +163,13 @@ class Circle(pygame.sprite.Sprite):
 
         # Create the sprite's image and rect
         self.image = pygame.Surface((width, height), pygame.SRCALPHA)
-        pygame.draw.circle(self.image, color, (width // 2, height // 2), width // 2)
-        self.rect = self.image.get_rect(center=(x, y))
+        pygame.draw.circle(
+            self.image,
+            color,
+            (width // 2, height // 2),
+            width // 2
+        )
+        self.rect = self.image.get_rect(topleft=(x, y))
 
         # Set the sprite's velocity using a Vector2
         self.velocity = pygame.math.Vector2(x_vel, y_vel)

--- a/examples/debug_example.py
+++ b/examples/debug_example.py
@@ -116,7 +116,11 @@ class Game:
                 )
             
             # Draw the rect overlay
-            self.rect_overlay.draw()
+            self.rect_overlay.draw(
+                collision_color="maroon",
+                normal_color="blue",
+                rect_width=2
+            )
 
             # Update the display and limit the framerate
             pygame.display.flip()

--- a/examples/debug_example.py
+++ b/examples/debug_example.py
@@ -9,7 +9,7 @@ FPS = 60
 
 
 class Game:
-    """A simple game that demonstrates the DebugOverlay class."""
+    """A simple game that demonstrates the debug overlay classes."""
 
     def __init__(self):
         """Initializes the game.

--- a/examples/debug_example.py
+++ b/examples/debug_example.py
@@ -38,6 +38,7 @@ class Game:
 
         # Initialize overlays
         self.debug_overlay = DebugOverlay()
+
         self.input_overlay = InputOverlay(
             expected_keys=[
                 pygame.K_UP,
@@ -55,6 +56,7 @@ class Game:
                 [0, 0]
             ]
         )
+
         self.rect_overlay = RectOverlay([self.boxes])
 
         # Set overlay fonts (debug_overlay uses default font)
@@ -85,11 +87,15 @@ class Game:
 
                 # Check for 1 key press, toggle debug visibility if pressed
                 if event.type == pygame.KEYDOWN and event.key == pygame.K_1:
-                    self.debug_overlay.visible = not self.debug_overlay.visible
+                    self.debug_overlay.toggle_visible()
                 
                 # Check for 2 key press, toggle input visibility if pressed
                 if event.type == pygame.KEYDOWN and event.key == pygame.K_2:
-                    self.input_overlay.visible = not self.input_overlay.visible
+                    self.input_overlay.toggle_visible()
+
+                # Check for 3 key press, toggle rect visibility if pressed
+                if event.type == pygame.KEYDOWN and event.key == pygame.K_3:
+                    self.rect_overlay.toggle_visible()
 
             # Draw background
             self.screen.fill("papayawhip")

--- a/pygkit/debug/__init__.py
+++ b/pygkit/debug/__init__.py
@@ -1,2 +1,3 @@
 from .debug_overlay import DebugOverlay
 from .input_overlay import InputOverlay
+from .rect_overlay import RectOverlay

--- a/pygkit/debug/debug_overlay.py
+++ b/pygkit/debug/debug_overlay.py
@@ -15,7 +15,7 @@ class DebugOverlay:
             None
         """
 
-        # Member variables
+        # Screen variable
         self.screen = pygame.display.get_surface()
 
         # Default font for the DebugOverlay

--- a/pygkit/debug/rect_overlay.py
+++ b/pygkit/debug/rect_overlay.py
@@ -1,0 +1,126 @@
+import pygame
+
+
+class RectOverlay:
+    def __init__(self, sprite_groups=None):
+        # Member variables
+        self.sprite_groups = sprite_groups
+
+        # Screen variable
+        self.screen = pygame.display.get_surface()
+
+        # Flag indicating whether the RectOverlay is visible
+        self.visible = True
+
+        # Surface used to draw the RectOverlay, set to the size of the screen
+        self.overlay_surface = pygame.Surface(
+            pygame.display.get_surface().get_size(),
+            pygame.SRCALPHA
+        )
+
+    def toggle_visible(self, enabled=None):
+        """Toggles the visibility of the DebugOverlay.
+
+        Args:
+            enabled (bool, optional): Whether to enable the overlay 
+                (default None).
+
+        Returns:
+            None
+        """
+
+        # Toggle the visibility if enabled is None, or set it to the given value
+        if enabled is None:
+            self.visible = not self.visible
+        else:
+            self.visible = enabled
+
+    def add_sprite_group(self, sprite_group):
+        """Adds a sprite group to the RectOverlay.
+
+        Args:
+            sprite_group (pygame.sprite.Group): The sprite group to add.
+
+        Returns:
+            None
+        """
+
+        # Add the sprite group to the list of sprite groups
+        self.sprite_groups.append(sprite_group)
+
+    def remove_sprite_group(self, sprite_group):
+        """Removes a sprite group from the RectOverlay.
+
+        Args:
+            sprite_group (pygame.sprite.Group): The sprite group to remove.
+
+        Returns:
+            None
+        """
+
+        # Remove the sprite group from the list of sprite groups
+        self.sprite_groups.remove(sprite_group)
+
+    def draw(self):
+        """Draws the RectOverlay on the screen.
+
+        This method clears the overlay surface, and then iterates through each
+        sprite in the sprite groups. It checks for collisions between the sprite
+        and other sprites in the groups. If a collision is detected, a red
+        rectangle is drawn around the sprite; otherwise, a green rectangle is
+        drawn. Finally, the overlay surface is drawn on the screen.
+
+        Args:
+            None
+
+        Returns:
+            None
+        """
+
+        # Clear the overlay surface
+        self.overlay_surface.fill((0, 0, 0, 0))
+
+        # Loop through each sprite in each sprite group
+        for sprite_group in self.sprite_groups:
+            for sprite in sprite_group:
+
+                # Initialize the colliding flag as False
+                colliding = False
+
+                # Loop through each group to check for collisions
+                for group in self.sprite_groups:
+                    collisions = pygame.sprite.spritecollide(
+                        sprite,
+                        group,
+                        False
+                    )
+
+                    # Loop through the collisions
+                    for collision in collisions: 
+                        if collision != sprite:
+                            colliding = True
+                            break
+                        
+                    # If the colliding flag is True, break the outer loop
+                    if colliding:
+                        break
+
+                # If the sprite is colliding, draw a red rectangle around it
+                if colliding:
+                    pygame.draw.rect(
+                        self.overlay_surface,
+                        "red",
+                        sprite.rect,
+                        1
+                    )
+                # If the sprite is not colliding, draw a green rectangle
+                else:
+                    pygame.draw.rect(
+                        self.overlay_surface,
+                        "green",
+                        sprite.rect,
+                        1
+                    )
+
+        # Draw the overlay surface to the screen
+        self.screen.blit(self.overlay_surface, (0, 0))

--- a/pygkit/debug/rect_overlay.py
+++ b/pygkit/debug/rect_overlay.py
@@ -8,7 +8,7 @@ class RectOverlay:
         sprite_groups (list, optional): A list of sprite groups to draw
             rectangles around (default None).
     """
-    
+
     def __init__(self, sprite_groups=None):
         """Initializes the RectOverlay with the given Pygame screen.
         
@@ -78,7 +78,7 @@ class RectOverlay:
         # Remove the sprite group from the list of sprite groups
         self.sprite_groups.remove(sprite_group)
 
-    def draw(self):
+    def draw(self, normal_color="green", collision_color="red", rect_width=1):
         """Draws the RectOverlay on the screen.
 
         This method clears the overlay surface, and then iterates through each
@@ -88,7 +88,12 @@ class RectOverlay:
         drawn. Finally, the overlay surface is drawn on the screen.
 
         Args:
-            None
+            normal_color (str, optional): The color to use for non-
+                    colliding sprites (default "green").
+            collision_color (str, optional): The color to use for colliding
+                sprites (default "red").
+            rect_width (int, optional): The width of the rectangles to draw
+                (default 1).
 
         Returns:
             None
@@ -126,17 +131,17 @@ class RectOverlay:
                 if colliding:
                     pygame.draw.rect(
                         self.overlay_surface,
-                        "red",
+                        collision_color,
                         sprite.rect,
-                        1
+                        rect_width
                     )
                 # If the sprite is not colliding, draw a green rectangle
                 else:
                     pygame.draw.rect(
                         self.overlay_surface,
-                        "green",
+                        normal_color,
                         sprite.rect,
-                        1
+                        rect_width
                     )
 
         # Draw the overlay surface to the screen

--- a/pygkit/debug/rect_overlay.py
+++ b/pygkit/debug/rect_overlay.py
@@ -3,6 +3,16 @@ import pygame
 
 class RectOverlay:
     def __init__(self, sprite_groups=None):
+        """Initializes the RectOverlay with the given Pygame screen.
+        
+        Args:
+            sprite_groups (list, optional): A list of sprite groups to draw
+                rectangles around (default None).
+                
+        Returns:
+            None
+        """
+        
         # Member variables
         self.sprite_groups = sprite_groups
 
@@ -100,7 +110,7 @@ class RectOverlay:
                         if collision != sprite:
                             colliding = True
                             break
-                        
+
                     # If the colliding flag is True, break the outer loop
                     if colliding:
                         break

--- a/pygkit/debug/rect_overlay.py
+++ b/pygkit/debug/rect_overlay.py
@@ -2,6 +2,13 @@ import pygame
 
 
 class RectOverlay:
+    """A class for drawing rectangles around sprites.
+    
+    Args:
+        sprite_groups (list, optional): A list of sprite groups to draw
+            rectangles around (default None).
+    """
+    
     def __init__(self, sprite_groups=None):
         """Initializes the RectOverlay with the given Pygame screen.
         
@@ -12,7 +19,7 @@ class RectOverlay:
         Returns:
             None
         """
-        
+
         # Member variables
         self.sprite_groups = sprite_groups
 

--- a/pygkit/debug/rect_overlay.py
+++ b/pygkit/debug/rect_overlay.py
@@ -99,6 +99,10 @@ class RectOverlay:
             None
         """
 
+        # Return if the overlay is not visible
+        if not self.visible:
+            return
+
         # Clear the overlay surface
         self.overlay_surface.fill((0, 0, 0, 0))
 


### PR DESCRIPTION
Solves #14 

Adds a RectOverlay class which, when given sprite groups, can use the draw method to draw rectangles around the sprites. The rectangles are green by default, red by default when colliding, and have a line width of 1. These three parameters can be adjusted when calling the draw method.

The debug_example file has also been updated to include a demo of this class, as well as some other changes to the file to accomodate the new features in a meaningful way (most notably, changing the sprites from squares to circles so the drawn rects are easier to see).

The RectOverlay was not done as a child of DebugOverlay because there wasn't enough in common to justify it. The only shared method between the two is the toggle_visible method, which is only 4 lines of code minus comments and docstring.