### PR TITLE
Improve AnimatedSprite API to load frames internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,34 @@ while True:
     )
 ```
 
+The library also includes an `AnimatedSprite` helper for managing sprite
+animations. You can point it at individual frame files or a sprite sheet (the
+class handles image loading for you), while the `update` method advances the
+animation using the elapsed time in seconds:
+
+```python
+import pygame
+from pygkit.sprite import AnimatedSprite
+
+pygame.init()
+clock = pygame.time.Clock()
+
+sprite = AnimatedSprite("./sprite_sheet.png", frame_size=(32, 32), frame_time=0.1)
+
+running = True
+while running:
+    dt = clock.tick(60) / 1000  # seconds
+    sprite.update(dt)
+```
+
+See `examples/animated_sprite_example.py` for a runnable demonstration that
+shows basic playback controls.
+
 ## Modules
 
 Pygkit will be designed to work alongside Pygame, providing additional functionality through various modules. Here are a few of the planned modules:
 
-- **Sprite**: A sprite sheet loader, an animated sprite class, etc.
+- **Sprite**: Sprite sheet helpers including an animated sprite class.
 - **AI**: Tools and algorithms to help you create engaging game AI.
 - **GUI**: Components for creating menus, text boxes, and other user interface elements.
 - **Debug**: Various debug overlays that can be used to display real-time game information during development.

--- a/examples/animated_sprite_example.py
+++ b/examples/animated_sprite_example.py
@@ -1,0 +1,133 @@
+"""Example showing how to use :class:`pygkit.sprite.AnimatedSprite`."""
+
+import os
+import tempfile
+
+import pygame
+
+from pygkit.sprite import AnimatedSprite
+
+# Constants
+SCREEN_WIDTH = 640
+SCREEN_HEIGHT = 360
+FPS = 60
+FRAME_SIZE = (64, 64)
+
+
+# Helper to build some simple animation frames without any assets
+def build_sprite_sheet() -> str:
+    """Create a temporary sprite sheet and return its file path."""
+
+    num_frames = 12
+    body_color = "#22d3ee"
+    outline_color = "#0f172a"
+
+    frames: list[pygame.Surface] = []
+    for i in range(num_frames):
+        surface = pygame.Surface(FRAME_SIZE, pygame.SRCALPHA)
+        surface.fill((0, 0, 0, 0))
+
+        angle = (360 / num_frames) * i
+        center = pygame.Vector2(surface.get_rect().center)
+
+        # Build a diamond and rotate it slightly each frame
+        base_points = [
+            pygame.Vector2(0, -22),
+            pygame.Vector2(20, 0),
+            pygame.Vector2(0, 22),
+            pygame.Vector2(-20, 0),
+        ]
+        points = [center + point.rotate(angle) for point in base_points]
+
+        pygame.draw.polygon(surface, body_color, points)
+        pygame.draw.polygon(surface, outline_color, points, width=4)
+
+        # Add a highlight that tracks the top tip as it rotates
+        tip = center + pygame.Vector2(0, -22).rotate(angle)
+        glow_radius = 8
+        pygame.draw.circle(surface, "#67e8f9", tip, glow_radius)
+        pygame.draw.circle(surface, "#ffffff", tip, glow_radius - 3)
+
+        frames.append(surface)
+
+    # Combine frames into a simple horizontal sprite sheet
+    sheet_width = FRAME_SIZE[0] * len(frames)
+    sheet = pygame.Surface((sheet_width, FRAME_SIZE[1]), pygame.SRCALPHA)
+    for i, frame in enumerate(frames):
+        sheet.blit(frame, (i * FRAME_SIZE[0], 0))
+
+    handle = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
+    pygame.image.save(sheet, handle.name)
+    handle.close()
+    return handle.name
+
+
+class Game:
+    """Minimal example that animates a sprite and lets you pause with SPACE."""
+
+    def __init__(self) -> None:
+        pygame.init()
+
+        self.screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
+        pygame.display.set_caption("AnimatedSprite example")
+        self.clock = pygame.time.Clock()
+
+        self._sheet_path = build_sprite_sheet()
+        self.sprite = AnimatedSprite(
+            self._sheet_path,
+            frame_size=FRAME_SIZE,
+            frame_time=0.12,
+            loop=True,
+            auto_play=True,
+            position=(
+                SCREEN_WIDTH // 2 - FRAME_SIZE[0] // 2,
+                SCREEN_HEIGHT // 2 - FRAME_SIZE[1] // 2,
+            ),
+        )
+        self.sprites = pygame.sprite.Group(self.sprite)
+
+    def run(self) -> None:
+        try:
+            while True:
+                dt = self.clock.tick(FPS) / 1000  # seconds
+
+                for event in pygame.event.get():
+                    if event.type == pygame.QUIT:
+                        return
+
+                    if event.type == pygame.KEYDOWN and event.key == pygame.K_SPACE:
+                        # Toggle the animation on and off
+                        if self.sprite.playing:
+                            self.sprite.pause()
+                        else:
+                            self.sprite.play()
+
+                self.sprites.update(dt)
+
+                self.screen.fill("#0f172a")
+                self.sprites.draw(self.screen)
+
+                # Simple text instructions
+                self._draw_instructions()
+
+                pygame.display.flip()
+        finally:
+            self._cleanup()
+
+    def _draw_instructions(self) -> None:
+        font = pygame.font.Font(None, 28)
+        status = "playing" if self.sprite.playing else "paused"
+        text = font.render(f"Space toggles animation ({status})", True, "#e2e8f0")
+        self.screen.blit(text, (20, SCREEN_HEIGHT - 40))
+
+    def _cleanup(self) -> None:
+        pygame.quit()
+        if hasattr(self, "_sheet_path") and os.path.exists(self._sheet_path):
+            try:
+                os.remove(self._sheet_path)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    Game().run()

--- a/pygkit/__init__.py
+++ b/pygkit/__init__.py
@@ -1,1 +1,10 @@
-from .debug import *
+"""Public package exports for Pygkit."""
+
+from . import debug as _debug
+from . import sprite as _sprite
+from .debug import *  # noqa: F401,F403
+from .sprite import *  # noqa: F401,F403
+
+__all__ = []
+__all__ += getattr(_debug, "__all__", [])
+__all__ += getattr(_sprite, "__all__", [])

--- a/pygkit/debug/__init__.py
+++ b/pygkit/debug/__init__.py
@@ -1,3 +1,7 @@
+"""Debug overlays exposed by Pygkit."""
+
 from .debug_overlay import DebugOverlay
 from .input_overlay import InputOverlay
 from .rect_overlay import RectOverlay
+
+__all__ = ["DebugOverlay", "InputOverlay", "RectOverlay"]

--- a/pygkit/sprite/__init__.py
+++ b/pygkit/sprite/__init__.py
@@ -1,0 +1,5 @@
+"""Sprite-related helpers for Pygkit."""
+
+from .animated_sprite import AnimatedSprite
+
+__all__ = ["AnimatedSprite"]

--- a/pygkit/sprite/animated_sprite.py
+++ b/pygkit/sprite/animated_sprite.py
@@ -1,0 +1,257 @@
+"""Utilities for working with animated sprites."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, List, Optional, Sequence, Tuple, Union
+
+import pygame
+
+FrameSource = Union[str, pygame.Surface, Sequence[Union[str, pygame.Surface]]]
+
+
+class AnimatedSprite(pygame.sprite.Sprite):
+    """A sprite that cycles through a sequence of frames.
+
+    The class is intentionally lightweight and only manages the image used for
+    rendering. Logic such as positioning the sprite or handling collisions
+    remains the responsibility of the consumer, just like with regular
+    ``pygame.sprite.Sprite`` instances.
+
+    Parameters
+    ----------
+    frames:
+        A sequence of ``pygame.Surface`` objects or file paths representing the
+        animation frames. A sprite sheet path or surface can also be supplied;
+        when ``frame_size`` is provided the sheet will be sliced automatically,
+        otherwise it will be treated as a single-frame animation.
+    frame_size:
+        The width and height of the individual frames inside the sprite sheet.
+        This is required whenever ``frames`` is a sprite sheet (a string path or
+        a surface containing multiple frames) and you want it to be sliced.
+    frame_durations:
+        An optional sequence specifying the duration of each frame in seconds.
+        When omitted every frame will use the same duration supplied via
+        ``frame_time``.
+    frame_time:
+        The duration, in seconds, each frame should be displayed when
+        ``frame_durations`` is not provided. Defaults to 0.1 seconds.
+    loop:
+        Whether the animation should loop. When disabled the animation will stop
+        on the last frame.
+    auto_play:
+        If ``True`` the animation will immediately begin playing.
+    position:
+        The initial top-left position of the sprite's rectangle.
+    """
+
+    def __init__(
+        self,
+        frames: FrameSource,
+        *,
+        frame_size: Optional[Tuple[int, int]] = None,
+        frame_durations: Optional[Sequence[float]] = None,
+        frame_time: float = 0.1,
+        loop: bool = True,
+        auto_play: bool = True,
+        position: Tuple[int, int] = (0, 0),
+    ) -> None:
+        super().__init__()
+
+        self._frames: List[pygame.Surface] = self._normalize_frames(
+            frames, frame_size
+        )
+        if not self._frames:
+            raise ValueError("AnimatedSprite requires at least one frame.")
+
+        self._durations = self._normalise_durations(
+            frame_durations, frame_time, len(self._frames)
+        )
+        self.loop = loop
+        self._playing = auto_play
+        self._frame_index = 0
+        self._elapsed = 0.0
+
+        self.image = self._frames[0]
+        self.rect = self.image.get_rect(topleft=position)
+
+    @staticmethod
+    def _normalize_frames(
+        frames: FrameSource, frame_size: Optional[Tuple[int, int]]
+    ) -> List[pygame.Surface]:
+        if isinstance(frames, (list, tuple)):
+            if all(isinstance(frame, pygame.Surface) for frame in frames):
+                return [frame.copy() for frame in frames]
+            if all(isinstance(frame, str) for frame in frames):
+                return [AnimatedSprite._load_image(path) for path in frames]
+            raise TypeError(
+                "All frames in the sequence must be pygame.Surface instances or file paths."
+            )
+
+        if isinstance(frames, pygame.Surface):
+            if frame_size is None:
+                return [frames.copy()]
+            return AnimatedSprite._slice_sprite_sheet(frames, frame_size)
+
+        if isinstance(frames, str):
+            sheet = AnimatedSprite._load_image(frames)
+            if frame_size is None:
+                return [sheet]
+            return AnimatedSprite._slice_sprite_sheet(sheet, frame_size)
+
+        raise TypeError(
+            "frames must be a sequence of Surfaces or paths, a Surface, or a file path."
+        )
+
+    @staticmethod
+    def _load_image(path: str) -> pygame.Surface:
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"Frame path does not exist: {path}")
+        return pygame.image.load(path).convert_alpha()
+
+    @staticmethod
+    def _slice_sprite_sheet(
+        sprite_sheet: pygame.Surface, frame_size: Tuple[int, int]
+    ) -> List[pygame.Surface]:
+        frame_width, frame_height = frame_size
+        if frame_width <= 0 or frame_height <= 0:
+            raise ValueError("frame_size values must be positive integers.")
+
+        sheet_width, sheet_height = sprite_sheet.get_size()
+        frames: List[pygame.Surface] = []
+        for top in range(0, sheet_height, frame_height):
+            if top + frame_height > sheet_height:
+                break
+            for left in range(0, sheet_width, frame_width):
+                if left + frame_width > sheet_width:
+                    break
+                frame = pygame.Surface((frame_width, frame_height), pygame.SRCALPHA)
+                frame.blit(
+                    sprite_sheet,
+                    (0, 0),
+                    pygame.Rect(left, top, frame_width, frame_height),
+                )
+                frames.append(frame)
+
+        return frames
+
+    @staticmethod
+    def _normalise_durations(
+        frame_durations: Optional[Sequence[float]],
+        frame_time: float,
+        frame_count: int,
+    ) -> List[float]:
+        if frame_durations is None:
+            if frame_time <= 0:
+                raise ValueError("frame_time must be greater than zero.")
+            return [frame_time for _ in range(frame_count)]
+
+        durations = list(frame_durations)
+        if len(durations) != frame_count:
+            raise ValueError("frame_durations must match the number of frames.")
+        if any(duration <= 0 for duration in durations):
+            raise ValueError("frame_durations must contain positive values.")
+        return durations
+
+    @property
+    def playing(self) -> bool:
+        """Whether the animation is currently playing."""
+
+        return self._playing
+
+    @property
+    def frame_index(self) -> int:
+        """The index of the currently displayed frame."""
+
+        return self._frame_index
+
+    def play(self) -> None:
+        """Resume the animation from the current frame."""
+
+        self._playing = True
+
+    def pause(self) -> None:
+        """Pause the animation without resetting the frame index."""
+
+        self._playing = False
+
+    def stop(self) -> None:
+        """Stop the animation and rewind to the first frame."""
+
+        self._playing = False
+        self._frame_index = 0
+        self._elapsed = 0.0
+        self.image = self._frames[self._frame_index]
+
+    def reset(self) -> None:
+        """Reset the animation to the first frame while preserving play state."""
+
+        self._frame_index = 0
+        self._elapsed = 0.0
+        self.image = self._frames[self._frame_index]
+
+    def update(self, dt: float) -> None:
+        """Advance the animation.
+
+        Parameters
+        ----------
+        dt:
+            The elapsed time in seconds since the last update call.
+        """
+
+        if not self._playing or not self._frames:
+            return
+
+        self._elapsed += dt
+
+        while self._elapsed >= self._durations[self._frame_index]:
+            self._elapsed -= self._durations[self._frame_index]
+            self._frame_index += 1
+
+            if self._frame_index >= len(self._frames):
+                if self.loop:
+                    self._frame_index = 0
+                else:
+                    self._frame_index = len(self._frames) - 1
+                    self._playing = False
+                    break
+
+        self.image = self._frames[self._frame_index]
+
+    def set_frame(self, index: int) -> None:
+        """Force the sprite to display the frame at ``index``."""
+
+        if not 0 <= index < len(self._frames):
+            raise IndexError("Frame index out of range.")
+
+        self._frame_index = index
+        self._elapsed = 0.0
+        self.image = self._frames[self._frame_index]
+
+    def add_frame(self, frame: pygame.Surface, duration: Optional[float] = None) -> None:
+        """Append a new frame to the animation."""
+
+        if not isinstance(frame, pygame.Surface):
+            raise TypeError("frame must be a pygame.Surface instance.")
+
+        self._frames.append(frame.copy())
+        if duration is None:
+            duration = self._durations[-1]
+        if duration <= 0:
+            raise ValueError("duration must be greater than zero.")
+        self._durations.append(duration)
+
+    def set_position(self, position: Tuple[int, int]) -> None:
+        """Update the sprite's position."""
+
+        self.rect.topleft = position
+
+    def center_on(self, position: Tuple[int, int]) -> None:
+        """Center the sprite on ``position``."""
+
+        self.rect.center = position
+
+    def frames(self) -> Iterable[pygame.Surface]:
+        """Return an iterable over the animation frames."""
+
+        return tuple(frame.copy() for frame in self._frames)


### PR DESCRIPTION
## Summary
- allow AnimatedSprite to accept frame file paths or sprite sheets, loading images internally to mirror typical Sprite usage
- update the animated sprite example to generate a temporary sprite sheet and construct the helper with a file path
- refresh the README snippet to demonstrate path-based AnimatedSprite usage
- refine the animated sprite example visuals with a rotating diamond sprite sheet

## Testing
- python -m compileall pygkit examples

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691132561cd4832a9f733f5527155686)